### PR TITLE
Add detailed console logging for voice reactivity debugging

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -47,11 +47,13 @@ const Index = () => {
   }, []);
 
   const analyzeAudio = useCallback(() => {
+    console.log('analyzeAudio called, isRecording:', isRecording);
     if (!analyserRef.current) return;
     
     const bufferLength = analyserRef.current.frequencyBinCount;
     const dataArray = new Uint8Array(bufferLength);
     analyserRef.current.getByteFrequencyData(dataArray);
+    console.log('analyzeAudio - dataArray slice (first 10):', dataArray.slice(0, 10));
     
     const average = dataArray.reduce((sum, value) => sum + value, 0) / bufferLength;
     const normalizedLevel = average / 255;
@@ -69,7 +71,7 @@ const Index = () => {
     }
     setBossExpression(newExpression);
     console.log('analyzeAudio - normalizedLevel:', normalizedLevel, 'newExpression:', newExpression);
-  }, []);
+  }, [isRecording, setAudioLevel, setBossExpression]);
 
   const setupSpeechRecognition = useCallback(() => {
     if (!('webkitSpeechRecognition' in window) && !('SpeechRecognition' in window)) {


### PR DESCRIPTION
This commit adds several console.log statements to `src/pages/Index.tsx` within the `analyzeAudio` function and its calling context. The goal is to capture the state of `isRecording`, the raw `dataArray` from the AnalyserNode, the calculated `normalizedLevel`, and the `determinedExpression` to diagnose why voice-based expression changes are not occurring for you.

Specifically:
- Logs `isRecording` status when `analyzeAudio` is called.
- Logs a slice of `dataArray` to check if it contains non-zero audio data.
- Ensures `useCallback` for `analyzeAudio` has appropriate dependencies.
- Keeps existing logs for `normalizedLevel`, `determinedExpression`, and props received by `BossAvatar`.

These changes are intended for diagnostic purposes. I will ask you to pull this branch, run the application, and provide the console output to help pinpoint the issue with voice volume detection.