### PR TITLE
feat: Implement 3D avatar creation and rendering with ReadyPlayerMe

### DIFF
--- a/src/components/BossAvatar.tsx
+++ b/src/components/BossAvatar.tsx
@@ -1,95 +1,134 @@
-
 import React from 'react';
 import { Card } from '@/components/ui/card';
+import { Avatar } from '@readyplayerme/visage';
 
 interface BossAvatarProps {
-  imageUrl: string | null;
+  modelUrl: string | null;
   expression: 'neutral' | 'confused' | 'anxious' | 'afraid';
   audioLevel: number;
 }
 
-export const BossAvatar: React.FC<BossAvatarProps> = ({ imageUrl, expression, audioLevel }) => {
-  console.log('BossAvatar props - expression:', expression, 'audioLevel:', audioLevel);
-  const getExpressionStyle = () => {
-    const intensity = audioLevel;
-    
-    switch (expression) {
-      case 'afraid':
-        return {
-          transform: `scale(${0.9 - intensity * 0.1}) translateY(${intensity * 10}px)`,
-          filter: 'brightness(0.8)',
-          borderColor: '#ef4444'
-        };
-      case 'anxious':
-        return {
-          transform: `scale(${0.95 - intensity * 0.05}) rotate(${intensity * 2}deg)`,
-          filter: 'brightness(0.9)',
-          borderColor: '#f59e0b'
-        };
-      case 'confused':
-        return {
-          transform: `scale(${0.98}) rotate(${Math.sin(Date.now() * 0.01) * intensity * 5}deg)`,
-          filter: 'brightness(0.95)',
-          borderColor: '#3b82f6'
-        };
-      default:
-        return {
-          transform: 'scale(1)',
-          filter: 'brightness(1)',
-          borderColor: '#d1d5db'
-        };
-    }
-  };
+const ARKIT_BLENDSHAPES = {
+  eyeBlinkLeft: "eyeBlinkLeft",
+  eyeBlinkRight: "eyeBlinkRight",
+  jawOpen: "jawOpen",
+  mouthSmileLeft: "mouthSmileLeft",
+  mouthSmileRight: "mouthSmileRight",
+  mouthFrownLeft: "mouthFrownLeft",
+  mouthFrownRight: "mouthFrownRight",
+  browInnerUp: "browInnerUp",
+  browDownLeft: "browDownLeft",
+  browDownRight: "browDownRight",
+  eyeWideLeft: "eyeWideLeft",
+  eyeWideRight: "eyeWideRight",
+  mouthFunnel: "mouthFunnel",
+  cheekPuff: "cheekPuff",
+  // Consider adding: mouthShrugUpper, mouthPressLeft, mouthPressRight, noseSneerLeft, noseSneerRight
+};
 
-  const getExpressionEmoji = () => {
-    switch (expression) {
-      case 'afraid': return '😰';
-      case 'anxious': return '😟';
-      case 'confused': return '🤔';
-      default: return '😐';
-    }
-  };
+const getBlendshapeValues = (
+  expression: 'neutral' | 'confused' | 'anxious' | 'afraid',
+  audioLevel: number
+): Record<string, number> => {
+  const base: Record<string, number> = Object.values(ARKIT_BLENDSHAPES).reduce((acc, shapeName) => {
+    acc[shapeName] = 0;
+    return acc;
+  }, {} as Record<string, number>);
 
-  const style = getExpressionStyle();
+  const intensity = Math.min(audioLevel * 1.5, 1.0); // Modulate intensity, cap at 1.0
+
+  switch (expression) {
+    case 'confused':
+      return {
+        ...base,
+        [ARKIT_BLENDSHAPES.browInnerUp]: 0.5 + intensity * 0.3,
+        [ARKIT_BLENDSHAPES.browDownLeft]: 0.4 + intensity * 0.2,
+        [ARKIT_BLENDSHAPES.mouthFrownLeft]: 0.3,
+        [ARKIT_BLENDSHAPES.jawOpen]: 0.05 + intensity * 0.05, // Slight jaw open for confusion
+      };
+    case 'anxious':
+      return {
+        ...base,
+        [ARKIT_BLENDSHAPES.eyeWideLeft]: 0.2 + intensity * 0.3,
+        [ARKIT_BLENDSHAPES.eyeWideRight]: 0.2 + intensity * 0.3,
+        [ARKIT_BLENDSHAPES.browInnerUp]: 0.3 + intensity * 0.2,
+        [ARKIT_BLENDSHAPES.mouthFrownLeft]: 0.2 + intensity * 0.1,
+        [ARKIT_BLENDSHAPES.mouthFrownRight]: 0.2 + intensity * 0.1,
+        [ARKIT_BLENDSHAPES.jawOpen]: 0.1 + intensity * 0.1,
+      };
+    case 'afraid':
+      return {
+        ...base,
+        [ARKIT_BLENDSHAPES.eyeWideLeft]: Math.min(0.6 + intensity * 0.4, 1.0),
+        [ARKIT_BLENDSHAPES.eyeWideRight]: Math.min(0.6 + intensity * 0.4, 1.0),
+        [ARKIT_BLENDSHAPES.browInnerUp]: Math.min(0.7 + intensity * 0.3, 1.0),
+        [ARKIT_BLENDSHAPES.jawOpen]: Math.min(0.3 + intensity * 0.3, 0.7), // Adjusted max for jawOpen
+        [ARKIT_BLENDSHAPES.mouthFunnel]: Math.min(0.4 + intensity * 0.3, 0.7), // mouthFunnel for fear
+      };
+    case 'neutral':
+    default:
+      // Subtle blink for neutral, driven by a slow sine wave or random timer for more natural feel
+      // This example is a static blink for simplicity, real implementation might need useEffect for timer
+      const blink = (Date.now() % 5000 > 4800) ? 1 : 0; // Blink every 5 seconds for 200ms
+      return {
+        ...base,
+        [ARKIT_BLENDSHAPES.eyeBlinkLeft]: blink,
+        [ARKIT_BLENDSHAPES.eyeBlinkRight]: blink,
+        // Could add very subtle jawOpen based on low audioLevel if desired for 'talking' appearance
+        [ARKIT_BLENDSHAPES.jawOpen]: Math.min(intensity * 0.2, 0.1), // Minimal movement for neutral speech
+      };
+  }
+};
+
+export const BossAvatar: React.FC<BossAvatarProps> = ({ modelUrl, expression, audioLevel }) => {
+  console.log('BossAvatar props - modelUrl:', modelUrl, 'expression:', expression, 'audioLevel:', audioLevel);
+
+  const blendshapes = getBlendshapeValues(expression, audioLevel);
+
+  // getExpressionEmoji is no longer needed as we are using 3D expressions.
+  // const getExpressionEmoji = () => { ... };
+
+  if (!modelUrl) {
+    return (
+      <Card className="p-8 text-center bg-gradient-to-br from-blue-50 to-indigo-50">
+        <h3 className="text-xl font-semibold mb-6">Boss Avatar</h3>
+        <div className="w-64 h-64 mx-auto rounded-full border-4 bg-gradient-to-br from-gray-200 to-gray-300 flex items-center justify-center">
+          <span className="text-6xl">⏳</span>
+        </div>
+        <p className="mt-4 text-gray-500">3D Avatar loading or not yet created.</p>
+      </Card>
+    );
+  }
 
   return (
-    <Card className="p-8 text-center bg-gradient-to-br from-blue-50 to-indigo-50">
-      <h3 className="text-xl font-semibold mb-6">Boss Avatar</h3>
-      
-      <div className="relative">
-        <div 
-          className="w-64 h-64 mx-auto rounded-full border-4 overflow-hidden transition-all duration-300 ease-out"
-          style={style}
-        >
-          {imageUrl ? (
-            <img 
-              src={imageUrl} 
-              alt="Boss Avatar" 
-              className="w-full h-full object-cover"
-            />
-          ) : (
-            <div className="w-full h-full bg-gradient-to-br from-gray-200 to-gray-300 flex items-center justify-center">
-              <span className="text-6xl">{getExpressionEmoji()}</span>
-            </div>
-          )}
-        </div>
-        
-        {/* Expression overlay */}
-        <div className="absolute top-2 right-2 text-4xl">
-          {getExpressionEmoji()}
-        </div>
+    <Card className="p-8 text-center bg-gradient-to-br from-blue-50 to-indigo-50 relative"> {/* Added relative for positioning text */}
+      <h3 className="text-xl font-semibold mb-6">Boss Avatar (3D)</h3>
+      <div className="w-64 h-64 mx-auto rounded-full border-4 overflow-hidden">
+        <Avatar
+          modelSrc={modelUrl}
+          style={{ width: '100%', height: '100%', display: 'block' }}
+          cameraInitialDistance={1.5}
+          cameraTargetHeight={1.6}
+          ambientLightIntensity={0.8} // Slightly increased ambient light
+          directionalLightIntensity={2.0} // Slightly decreased direct light
+          blendshapes={blendshapes}
+          headMovement={true} // Enable head movement based on expression/audio
+          animationSrc={expression === 'neutral' ? undefined : undefined} // Placeholder for specific animation files
+        />
       </div>
       
+      {/* Removed 2D emoji overlay */}
+
       <div className="mt-4 space-y-2">
         <div className="text-sm font-medium capitalize text-gray-700">
-          Expression: {expression}
+          Current State: {expression}
         </div>
-        
-        {audioLevel > 0.3 && (
+        {audioLevel > 0.1 && ( // Lowered threshold for showing text
           <div className="text-xs text-gray-500 animate-fade-in">
-            {expression === 'afraid' && "I hear you're really upset..."}
-            {expression === 'anxious' && "This seems to be bothering you..."}
-            {expression === 'confused' && "I'm listening to understand..."}
+            {expression === 'afraid' && "Visualizing high intensity..."}
+            {expression === 'anxious' && "Visualizing some concern..."}
+            {expression === 'confused' && "Visualizing contemplation..."}
+            {expression === 'neutral' && audioLevel > 0.1 && "Processing speech..."}
           </div>
         )}
       </div>


### PR DESCRIPTION
This commit introduces the 3D avatar pipeline using Ready Player Me:
- Integrates `@readyplayerme/react-avatar-creator` to allow you to create a 3D avatar via an iframe modal. The modal is triggered after a 2D image is selected and boss email is provided. The exported .glb model URL is captured.
- Installs `@readyplayerme/visage` and `three` as dependencies.
- Refactors the `BossAvatar` component to use `<Avatar>` from Visage to render the 3D model using the .glb URL.
- Implements 3D facial expression handling in `BossAvatar`:
    - Maps the application's `expression` state ('neutral', 'confused', 'anxious', 'afraid') and `audioLevel` to ARKit blendshape values.
    - Passes these blendshape values to the Visage `<Avatar>` component (assuming a `blendshapes` prop) to drive facial animations.
    - Includes subtle blinking/talking animation for the 'neutral' state and head movement.
- Updates `Index.tsx` to manage state for `avatarModelUrl`, visibility of the AvatarCreator modal, and to pass the model URL to the `BossAvatar` component.
- The 'Start Venting' button is now enabled only after a 3D model URL is obtained and boss email is present.

Note: This assumes that the necessary dependencies (`@readyplayerme/react-avatar-creator`, `@readyplayerme/visage`, `three`) can be installed in your environment, potentially using `--legacy-peer-deps` due to a React version conflict identified with `@react-three/fiber` requiring React 19.