### PR TITLE
I've updated the ReadyPlayerMe subdomain for the AvatarCreator.

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -205,7 +205,7 @@ const Index = () => {
             </DialogHeader>
             <div style={{ width: '100%', height: 'calc(80vh - 100px)', border: 'none' }}> {/* Adjusted height */}
               <AvatarCreator
-                subdomain="bossvent-demo"
+                subdomain="bossvent" // Changed from "bossvent-demo"
                 config={{ clearCache: true, bodyType: 'fullbody', language: 'en' }}
                 onAvatarExported={(event: AvatarExportedEvent) => {
                   console.log(`Avatar exported: ${event.data.url}`);


### PR DESCRIPTION
This changes the placeholder subdomain 'bossvent-demo' to your provided 'bossvent' in the `<AvatarCreator>` component within `Index.tsx`.

This should allow the Ready Player Me iframe editor to load correctly by referencing a valid application registered in the RPM Studio.